### PR TITLE
Added geminox manufacturer and added missing sensors for esphome

### DIFF
--- a/custom_components/sat/esphome/__init__.py
+++ b/custom_components/sat/esphome/__init__.py
@@ -22,6 +22,8 @@ DATA_REL_MOD_LEVEL = "modulation"
 DATA_SLAVE_MEMBERID = "boiler_member_id"
 DATA_BOILER_TEMPERATURE = "boiler_temperature"
 DATA_RETURN_TEMPERATURE = "return_temperature"
+DATA_BOILER_CAPACITY = "max_capacity"
+DATA_REL_MIN_MOD_LEVEL = "min_mod_level"
 
 DATA_DHW_SETPOINT_MINIMUM = "dhw_min_temperature"
 DATA_DHW_SETPOINT_MAXIMUM = "dhw_max_temperature"
@@ -135,6 +137,20 @@ class SatEspHomeCoordinator(SatDataUpdateCoordinator, SatEntityCoordinator):
             return float(value)
 
         return super().relative_modulation_value
+    
+    @property
+    def boiler_capacity(self) -> float | None:
+        if (value := self.get(SENSOR_DOMAIN, DATA_BOILER_CAPACITY)) is not None:
+            return float(value)
+
+        return super().boiler_capacity
+    
+    @property
+    def minimum_relative_modulation_value(self) -> float | None:
+        if (value := self.get(SENSOR_DOMAIN, DATA_REL_MIN_MOD_LEVEL)) is not None:
+            return float(value)
+        
+        return super().minimum_relative_modulation_value
 
     @property
     def maximum_relative_modulation_value(self) -> float | None:

--- a/custom_components/sat/manufacturer.py
+++ b/custom_components/sat/manufacturer.py
@@ -14,6 +14,10 @@ class ManufacturerFactory:
         if member_id == -1:
             from custom_components.sat.manufacturers.simulator import Simulator
             return Simulator()
+        
+        if member_id == 4:
+            from custom_components.sat.manufacturers.geminox import Geminox
+            return Geminox()
 
         if member_id == 6:
             from custom_components.sat.manufacturers.ideal import Ideal

--- a/custom_components/sat/manufacturers/geminox.py
+++ b/custom_components/sat/manufacturers/geminox.py
@@ -1,0 +1,7 @@
+from custom_components.sat.manufacturer import Manufacturer
+
+
+class Geminox(Manufacturer):
+    @property
+    def name(self) -> str:
+        return 'Geminox'


### PR DESCRIPTION
My geminox gas boiler returns 4 as the ID3:LB value.

I added 2 missing sensors for the esphome implementation, they are based on the default names in olegtarasov's branch, but I guess we will need to clean up the naming when the sensors are added in an official esphome release anyway.