### PR TITLE
ESPHome DHW active fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ number:
       name: t_dhw_set
       step: 1
       restore_value: true
+      initial_value: 45
     t_set:
       name: t_set
       restore_value: true
+      initial_value: 10
     max_t_set:
       name: max_t_set
       step: 1
@@ -153,6 +155,8 @@ binary_sensor:
   - platform: opentherm
     flame_on:
       name: flame_on
+    dhw_active:
+      name: dhw_active
 
 switch:
   - platform: opentherm

--- a/custom_components/sat/esphome/__init__.py
+++ b/custom_components/sat/esphome/__init__.py
@@ -15,6 +15,7 @@ from ..helpers import float_value, int_value
 
 # Sensors
 DATA_FLAME_ACTIVE = "flame_on"
+DATA_DHW_ACTIVE = "dhw_active"
 DATA_REL_MOD_LEVEL = "rel_mod_level"
 DATA_SLAVE_MEMBERID = "device_id"
 DATA_BOILER_TEMPERATURE = "t_boiler"
@@ -84,7 +85,7 @@ class SatEspHomeCoordinator(SatDataUpdateCoordinator, SatEntityCoordinator):
 
     @property
     def hot_water_active(self) -> bool:
-        return self.get(binary_sensor.DOMAIN, DATA_DHW_ENABLE) == DeviceState.ON
+        return self.get(binary_sensor.DOMAIN, DATA_DHW_ACTIVE) == DeviceState.ON
 
     @property
     def setpoint(self) -> float | None:
@@ -140,6 +141,7 @@ class SatEspHomeCoordinator(SatDataUpdateCoordinator, SatEntityCoordinator):
         # Create a list of entities that we track
         entities = list(filter(lambda entity: entity is not None, [
             self._get_entity_id(sensor.DOMAIN, DATA_FLAME_ACTIVE),
+            self._get_entity_id(switch.DOMAIN, DATA_DHW_ACTIVE),
             self._get_entity_id(sensor.DOMAIN, DATA_REL_MOD_LEVEL),
             self._get_entity_id(sensor.DOMAIN, DATA_SLAVE_MEMBERID),
             self._get_entity_id(sensor.DOMAIN, DATA_BOILER_TEMPERATURE),

--- a/custom_components/sat/esphome/__init__.py
+++ b/custom_components/sat/esphome/__init__.py
@@ -140,8 +140,8 @@ class SatEspHomeCoordinator(SatDataUpdateCoordinator, SatEntityCoordinator):
 
         # Create a list of entities that we track
         entities = list(filter(lambda entity: entity is not None, [
-            self._get_entity_id(sensor.DOMAIN, DATA_FLAME_ACTIVE),
-            self._get_entity_id(switch.DOMAIN, DATA_DHW_ACTIVE),
+            self._get_entity_id(binary_sensor.DOMAIN, DATA_FLAME_ACTIVE),
+            self._get_entity_id(binary_sensor.DOMAIN, DATA_DHW_ACTIVE),
             self._get_entity_id(sensor.DOMAIN, DATA_REL_MOD_LEVEL),
             self._get_entity_id(sensor.DOMAIN, DATA_SLAVE_MEMBERID),
             self._get_entity_id(sensor.DOMAIN, DATA_BOILER_TEMPERATURE),


### PR DESCRIPTION
Currently, ESPHome-based OpenTherm gateways' data on DHW usage is not working correctly; `dhw_on` is a toggle switch for DHW, but not the `binary_sensor`.

I've added `dhw_active` sensor for example ESPHome configuration and changed data retrieval logic in ESPHome part of the component so that it could understand that the boiler is "stuck on" due to making domestic hot water.

I've also added initial values for ESPHome configuration for `t_set` (both CH and DHW), as some boilers (like Baxi with Bertelli main board) exhibit undefined behavior if they receive zeroes during writing of these parameters, like heating water until bimetallic failsafe thermostat triggers at 115°C and stops gas flow in almost-a-disaster-scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default initial values for OpenTherm DHW and heating temperature setpoints in ESPHome configuration.
  * Introduced a new DHW activity sensor to indicate when the domestic hot water system is active.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->