### PR TITLE
Improve/fix support for Bosch Junkers boilers through EMS-ESP

### DIFF
--- a/custom_components/sat/mqtt/ems.py
+++ b/custom_components/sat/mqtt/ems.py
@@ -23,7 +23,7 @@ DATA_CENTRAL_HEATING = "heatingactive"
 DATA_BOILER_CAPACITY = "nompower"
 
 DATA_REL_MIN_MOD_LEVEL = "burnminpower"
-DATA_MAX_REL_MOD_LEVEL_SETTING = "burnmaxpower"
+DATA_MAX_REL_MOD_LEVEL_SETTING = "selburnpow"
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -108,7 +108,9 @@ class SatEmsMqttCoordinator(SatMqttCoordinator):
         return [DATA_BOILER_DATA]
 
     async def async_set_control_setpoint(self, value: float) -> None:
-        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {0 if value == 10 else value}}}')
+        # Minimum valid setting for Bosch/Junkers boiler seems to be 12°. Might be different
+        # for other boilers, do we need a configuration setting for this?
+        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {max(value, 12)}}}')
 
         await super().async_set_control_setpoint(value)
 
@@ -122,12 +124,18 @@ class SatEmsMqttCoordinator(SatMqttCoordinator):
         await super().async_set_control_thermostat_setpoint(value)
 
     async def async_set_heater_state(self, state: DeviceState) -> None:
-        await self._publish_command(f'{{"cmd": "heatingoff", "value": "{DATA_OFF if state == DeviceState.ON else DATA_ON}"}}')
+        # Do not send 'heatingoff' command, as this leads to EMS toggling the boiler between
+        # pre-set heating and selected flow temperature. Instead, control on/off solely by setting
+        # a low flow temperature (SAT already does this).
+        # (see https://github.com/emsesp/EMS-ESP32/discussions/2641#discussioncomment-14611481)
 
         await super().async_set_heater_state(state)
 
     async def async_set_control_max_relative_modulation(self, value: int) -> None:
-        await self._publish_command(f'{{"cmd": "burnmaxpower", "value": {max(value, 20)}}}')
+        # Do not set 'burnmaxpower' as this is an EEPROM-stored value and will wear out the EEPROM.
+        # Use 'selburnpow' instead.  
+        # (see https://github.com/emsesp/EMS-ESP32/discussions/2641#discussioncomment-14611481)
+        await self._publish_command(f'{{"cmd": "selburnpow", "value": {max(value, 20)}}}')
 
         await super().async_set_control_max_relative_modulation(value)
 

--- a/custom_components/sat/mqtt/ems.py
+++ b/custom_components/sat/mqtt/ems.py
@@ -108,9 +108,9 @@ class SatEmsMqttCoordinator(SatMqttCoordinator):
         return [DATA_BOILER_DATA]
 
     async def async_set_control_setpoint(self, value: float) -> None:
-        # Minimum valid setting for Bosch/Junkers boiler seems to be 12°. Might be different
-        # for other boilers, do we need a configuration setting for this?
-        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {max(value, 12)}}}')
+        # Minimum valid setting for Bosch/Junkers boiler seems to be 12°. 
+        # Lower values set the boiler to 12° except 0° which sets the boiler to 5°.
+        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {0 if value < 12 else value}}}')
 
         await super().async_set_control_setpoint(value)
 

--- a/custom_components/sat/mqtt/ems.py
+++ b/custom_components/sat/mqtt/ems.py
@@ -23,7 +23,7 @@ DATA_CENTRAL_HEATING = "heatingactive"
 DATA_BOILER_CAPACITY = "nompower"
 
 DATA_REL_MIN_MOD_LEVEL = "burnminpower"
-DATA_MAX_REL_MOD_LEVEL_SETTING = "selburnpow"
+DATA_MAX_REL_MOD_LEVEL_SETTING = "burnmaxpower"
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class SatEmsMqttCoordinator(SatMqttCoordinator):
     async def async_set_control_setpoint(self, value: float) -> None:
         # Minimum valid setting for Bosch/Junkers boiler seems to be 12°. 
         # Lower values set the boiler to 12° except 0° which sets the boiler to 5°.
-        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {0 if value < 12 else value}}}')
+        await self._publish_command(f'{{"cmd": "selflowtemp", "value": {max(value, 12)}}}')
 
         await super().async_set_control_setpoint(value)
 

--- a/custom_components/sat/mqtt/ems.py
+++ b/custom_components/sat/mqtt/ems.py
@@ -125,8 +125,12 @@ class SatEmsMqttCoordinator(SatMqttCoordinator):
         await super().async_set_control_thermostat_setpoint(value)
 
     async def async_set_heater_state(self, state: DeviceState) -> None:
-        await self._publish_command(f'{{"cmd": "heatingactivated", "value": "{DATA_ON if state == DeviceState.ON else DATA_OFF}"}}')
-
+        # Do not send 'heatingoff' command, as this leads to EMS toggling the boiler between
+        # pre-set heating and selected flow temperature. Instead, control on/off solely by setting
+        # a low flow temperature (SAT already does this).
+        # (see https://github.com/emsesp/EMS-ESP32/discussions/2641#discussioncomment-14611481)
+        # The alternative command 'heatingactivated` also interferes with EMS, so sending nothing
+        # here seems to be the correct way to handle it.
         await super().async_set_heater_state(state)
 
     async def async_set_control_max_relative_modulation(self, value: int) -> None:


### PR DESCRIPTION
Improve/fix support for Bosch Junkers boilers through EMS-ESP. 

See https://github.com/Alexwijn/SAT/issues/109

Fixes flow temperature behaving erratically because of wrong commands send to EMS-ESP. Changed commands according to feedback from EMS-ESP developers (https://github.com/emsesp/EMS-ESP32/discussions/2641#discussioncomment-14611481). 

Changes running reliably with my Bosch Junkers Condens GC7000i for a couple of weeks.

<!--
  This file is used as the default template for pull requests.
  It provides a checklist that ensures new contributions follow project conventions.
-->

# Pull Request Template

## Summary
- [ x] I have added a clear, concise title and description.
- [ x] The description includes what has changed and why it matters.

## Checklist
- [ x] I followed the coding style guidelines (PEP8, Home Assistant patterns).
- [na ] All new code is typed with type hints where appropriate.
- [ na] I added or updated unit tests that cover my changes.
- [na ] Tests run locally and on CI without errors.
- [ na] Documentation updates (README, docs, comments) are included if relevant.

## Screenshots / Visuals
(Add screenshots if the PR introduces UI changes.)

## Additional Notes
(Any extra information for reviewers.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced a minimum boiler control setpoint (now clamped to 12) for safer operation.
  * Enforced a minimum for maximum relative modulation (now clamped to 20) to reduce wear and ensure stable performance.
  * Stopped sending an explicit heating activation command; heating is now managed via flow-temperature behavior for clearer state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->