### PR TITLE
Check whether heater needs to be turned off be because all valves are closed.

### DIFF
--- a/custom_components/sat/climate.py
+++ b/custom_components/sat/climate.py
@@ -987,12 +987,16 @@ class SatClimate(SatEntity, ClimateEntity, RestoreEntity):
         _LOGGER.debug("Attempting to set heater state to: %s", state)
 
         if state == DeviceState.ON:
-            if self._coordinator.device_active:
-                _LOGGER.info("Heater is already active. No action taken.")
+            if not self.valves_open:
+                if self._coordinator.device_active:
+                    _LOGGER.info("Valves closed while heater active. Turning off.")
+                    await self._coordinator.async_set_heater_state(DeviceState.OFF)
+                else:
+                    _LOGGER.warning("Cannot turn on heater: no valves are open.")
                 return
 
-            if not self.valves_open:
-                _LOGGER.warning("Cannot turn on heater: no valves are open.")
+            if self._coordinator.device_active:
+                _LOGGER.info("Heater is already active. No action taken.")
                 return
 
         elif state == DeviceState.OFF:


### PR DESCRIPTION
If all valves close while the heater state is on, the heater state wasn't turned off. The valve check has been moved up and the heater state is forced off, if all valves are closed while SAT decides it should heat.

My setup is as follows:

- 9 rooms with all of them a generic_thermostat helper, temperature sensor and underfloor heating valve switch:
  - 8 rooms are configured with a cold tolerance and warm tolerance of 0
  - 1 room is the "cold" room of the house and looses a lot of heat. The boiler can't heat that room when the error is low, and PWM isn't always kicking in. I've set the cold tolerance for this room to 0.3.
- Sonoff SNZB-02D thermometers. Yes, it's very clear these do not suffice. The Xiaomi's are in the mail.
- DIYless controller with ESPHome.
- SAT configuration is as follows:
  - Setup:
    - Indoor temperature sensor: living room
    - Outdoor temperature sensor: WeerLive (a “real” sensor is in the mail)
    - Humidity sensor: living room
    - System: UFH
    - Area:
      - Primary: living room
      - Rooms: the 8 remaining thermostats
    - Overshoot value: 17.1
  - Settings:
    - General:
      - PID: Adaptive Controller
      - Minimum setpoint: Return Temperature
      - Mode: Comfort
      - Max setpoint: 50
      - Coefficient: 3.5
      - Minimum adjustment factor: 0.2
      - No contact sensors
    - Presets: default
    - System configuration:
      - Everything default except for Duty Cycles: set to normal (3x per hour); I had a lot of short cycling, but that was fixed by setting dynamic minimal setpoint
    - Advanced:
      - Dynamic minimal setpoint: enabled
      - The rest is at default I think

I've implemented this fix locally and it kicked in 4 times over the past day and suppressed heating for 2.5 hours in total. The primary cause seems to be the cold room I mentioned. The generic_thermostat for that room has a cold tolerance of 0.3. However, it is including the error of that room in its calculations regardless of the generic_thermostat state. Arguably the correct fix is to change that. I may still do this for my own setup and upstream those changes, but that doesn't negate the need for this fix. The boiler should never be turned off if all valves are closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved heater state management** – Enhanced heater behavior when valves are not open. The system now properly logs and prevents heater activation in incompatible conditions, preventing potential operational issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->