### PR TITLE
Fix ESPHome entity lookup after unique ID migration

### DIFF
--- a/custom_components/sat/esphome/__init__.py
+++ b/custom_components/sat/esphome/__init__.py
@@ -192,7 +192,24 @@ class SatEspHomeCoordinator(SatDataUpdateCoordinator, SatEntityCoordinator):
         await super().async_set_control_max_setpoint(value)
 
     def _get_entity_id(self, domain: str, key: str):
-        unique_id = f"{self._mac_address.upper()}-{domain}-{key}"
+        mac_address = self._mac_address.upper()
+        domain_casefold = domain.casefold()
+        key_casefold = key.casefold()
+        _LOGGER.debug(f"Attempting to find an ESPHome entity with the unique_id format {mac_address}/*/{domain}/{key}")
+
+        for entry in self._entities:
+            if entry.platform != esphome.DOMAIN or entry.domain != domain:
+                continue
+
+            unique_id_parts = entry.unique_id.casefold().split("/")
+            if len(unique_id_parts) != 4:
+                continue
+
+            entry_mac_address, _, entry_domain, entry_key = unique_id_parts
+            if entry_mac_address == mac_address.casefold() and entry_domain == domain_casefold and entry_key == key_casefold:
+                return entry.entity_id
+
+        unique_id = f"{mac_address}-{domain}-{key}"
         _LOGGER.debug(f"Attempting to find the unique_id of {unique_id}")
         return self._entity_registry.async_get_entity_id(domain, esphome.DOMAIN, unique_id)
 

--- a/tests/test_esphome.py
+++ b/tests/test_esphome.py
@@ -1,0 +1,125 @@
+import sys
+from types import SimpleNamespace
+from types import ModuleType
+
+from homeassistant.components import number, sensor
+
+esphome = ModuleType("homeassistant.components.esphome")
+esphome.DOMAIN = "esphome"
+sys.modules["homeassistant.components.esphome"] = esphome
+
+from custom_components.sat.esphome import SatEspHomeCoordinator
+
+
+class EntityRegistry:
+    def __init__(
+        self,
+        entity_id: str | None = None,
+        domain: str = number.DOMAIN,
+        platform: str = esphome.DOMAIN,
+        unique_id: str = "94:E6:86:3C:EE:6C-number-t_set",
+    ) -> None:
+        self.entity_id = entity_id
+        self.domain = domain
+        self.platform = platform
+        self.unique_id = unique_id
+
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str) -> str | None:
+        if domain == self.domain and platform == self.platform and unique_id == self.unique_id:
+            return self.entity_id
+
+        return None
+
+
+def create_coordinator(entity_registry: EntityRegistry, entities: list[SimpleNamespace]) -> SatEspHomeCoordinator:
+    coordinator = SatEspHomeCoordinator.__new__(SatEspHomeCoordinator)
+    coordinator._mac_address = "94:E6:86:3C:EE:6C"
+    coordinator._entity_registry = entity_registry
+    coordinator._entities = entities
+    return coordinator
+
+
+def test_get_entity_id_supports_legacy_esphome_unique_id() -> None:
+    coordinator = create_coordinator(EntityRegistry("number.opentherm_t_set"), [])
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") == "number.opentherm_t_set"
+
+
+def test_get_entity_id_supports_current_esphome_unique_id() -> None:
+    coordinator = create_coordinator(
+        EntityRegistry(),
+        [
+            SimpleNamespace(
+                platform=esphome.DOMAIN,
+                domain=number.DOMAIN,
+                unique_id="94:E6:86:3C:EE:6C/0/number/t_set",
+                entity_id="number.lavanderia_opentherm_t_set",
+            ),
+        ],
+    )
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") == "number.lavanderia_opentherm_t_set"
+
+
+def test_get_entity_id_prefers_current_esphome_unique_id() -> None:
+    coordinator = create_coordinator(
+        EntityRegistry("number.legacy_opentherm_t_set"),
+        [
+            SimpleNamespace(
+                platform=esphome.DOMAIN,
+                domain=number.DOMAIN,
+                unique_id="94:E6:86:3C:EE:6C/0/number/t_set",
+                entity_id="number.current_opentherm_t_set",
+            ),
+        ],
+    )
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") == "number.current_opentherm_t_set"
+
+
+def test_get_entity_id_ignores_other_domains_for_current_esphome_unique_id() -> None:
+    coordinator = create_coordinator(
+        EntityRegistry(),
+        [
+            SimpleNamespace(
+                platform=esphome.DOMAIN,
+                domain=sensor.DOMAIN,
+                unique_id="94:E6:86:3C:EE:6C/0/sensor/t_set",
+                entity_id="sensor.lavanderia_opentherm_t_set",
+            ),
+        ],
+    )
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") is None
+
+
+def test_get_entity_id_ignores_other_platforms_for_current_esphome_unique_id() -> None:
+    coordinator = create_coordinator(
+        EntityRegistry(),
+        [
+            SimpleNamespace(
+                platform="mqtt",
+                domain=number.DOMAIN,
+                unique_id="94:E6:86:3C:EE:6C/0/number/t_set",
+                entity_id="number.lavanderia_opentherm_t_set",
+            ),
+        ],
+    )
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") is None
+
+
+def test_get_entity_id_ignores_malformed_current_esphome_unique_id_and_uses_legacy_fallback() -> None:
+    coordinator = create_coordinator(
+        EntityRegistry("number.legacy_opentherm_t_set"),
+        [
+            SimpleNamespace(
+                platform=esphome.DOMAIN,
+                domain=number.DOMAIN,
+                unique_id="94:E6:86:3C:EE:6C/0/number/opentherm/t_set",
+                entity_id="number.lavanderia_opentherm_t_set",
+            ),
+        ],
+    )
+
+    assert coordinator._get_entity_id(number.DOMAIN, "t_set") == "number.legacy_opentherm_t_set"


### PR DESCRIPTION
## Summary
- Prefer the current ESPHome unique_id format when resolving SAT gateway entities
- Parse migrated ESPHome unique IDs as {mac}/{sub_device_id}/{platform}/{object_id} to avoid accidental suffix matches
- Fall back to the legacy ESPHome unique_id format for older or unmigrated registries
- Add focused tests for current, legacy, preference, domain mismatch, and malformed unique_id lookup behavior

Fixes #175

## Testing
- .venv/bin/python -m pytest tests/test_esphome.py
- Deployed the patched ESPHome SAT module to a Home Assistant 2026.8.3 instance and restarted Home Assistant Core
- Confirmed the affected ESPHome OpenTherm entities use the migrated unique_id format, including number.t_set, number.max_t_set, sensor.t_boiler, and binary_sensor.flame_on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESPHome entity matching across legacy and current unique ID formats.
  * Prevented entities from unrelated domains or malformed identifiers from being matched.
  * Ensured current-format entity IDs take precedence when both formats are available.

* **Tests**
  * Added coverage for legacy IDs, current IDs, domain filtering, precedence, and malformed identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->